### PR TITLE
Add basic SessionTracker

### DIFF
--- a/src/main/kotlin/com/canefe/story/Story.kt
+++ b/src/main/kotlin/com/canefe/story/Story.kt
@@ -26,6 +26,7 @@ import com.canefe.story.player.NPCManager
 import com.canefe.story.player.PlayerManager
 import com.canefe.story.quest.QuestListener
 import com.canefe.story.quest.QuestManager
+import com.canefe.story.session.SessionManager
 import com.canefe.story.service.AIResponseService
 import com.canefe.story.util.DisguiseManager
 import com.canefe.story.util.PluginUtils
@@ -95,11 +96,12 @@ class Story :
 	lateinit var npcResponseService: NPCResponseService
 	lateinit var worldInformationManager: WorldInformationManager
 
-	lateinit var npcActionIntentRecognizer: NPCActionIntentRecognizer
+        lateinit var npcActionIntentRecognizer: NPCActionIntentRecognizer
 
-	lateinit var scheduleManager: NPCScheduleManager
-	lateinit var npcContextGenerator: NPCContextGenerator
-	lateinit var lorebookManager: LoreBookManager
+        lateinit var scheduleManager: NPCScheduleManager
+        lateinit var npcContextGenerator: NPCContextGenerator
+        lateinit var lorebookManager: LoreBookManager
+        lateinit var sessionManager: SessionManager
 
 	private lateinit var commandManager: CommandManager
 
@@ -198,7 +200,9 @@ class Story :
 
 	private fun initializeManagers() {
 		// Initialize the time service
-		timeService = TimeService(this)
+                timeService = TimeService(this)
+
+                sessionManager = SessionManager.getInstance(this)
 
 		factionManager = FactionManager(this)
 		disguiseManager = DisguiseManager(this)
@@ -244,13 +248,14 @@ class Story :
 		mythicMobConversation = MythicMobConversationIntegration(this)
 	}
 
-	override fun onDisable() {
-		logger.info("Story has been disabled.")
-		CommandAPI.onDisable()
-		scheduleManager.shutdown()
-		commandManager.onDisable()
-		eventManager.unregisterAll()
-	}
+        override fun onDisable() {
+                logger.info("Story has been disabled.")
+                CommandAPI.onDisable()
+                scheduleManager.shutdown()
+                sessionManager.shutdown()
+                commandManager.onDisable()
+                eventManager.unregisterAll()
+        }
 
 	/**
 	 * Safely stops the plugin by properly ending all ongoing conversations first
@@ -284,8 +289,10 @@ class Story :
 			// Cancel all scheduled tasks
 			conversationManager.cancelScheduledTasks()
 
-			// Shutdown scheduled tasks
-			scheduleManager.shutdown()
+                        // Shutdown scheduled tasks
+                        scheduleManager.shutdown()
+
+                        sessionManager.shutdown()
 
 			// Unregister commands
 			commandManager.onDisable()

--- a/src/main/kotlin/com/canefe/story/command/story/StoryCommand.kt
+++ b/src/main/kotlin/com/canefe/story/command/story/StoryCommand.kt
@@ -5,6 +5,7 @@ import com.canefe.story.command.base.BaseCommand
 import com.canefe.story.command.story.location.LocationCommand
 import com.canefe.story.command.story.npc.NPCCommand
 import com.canefe.story.command.story.quest.QuestCommand
+import com.canefe.story.command.story.session.SessionCommand
 import com.canefe.story.util.Msg.sendRaw
 import com.canefe.story.util.Msg.sendSuccess
 import dev.jorel.commandapi.CommandAPICommand
@@ -27,11 +28,12 @@ class StoryCommand(
 					sender.sendRaw(helpMessage)
 				},
 			).withSubcommand(getLocationCommand())
-			.withSubcommand(getQuestCommand())
-			.withSubcommand(getHelpCommand())
-			.withSubcommand(getReloadCommand())
-			.withSubcommand(getNPCCommand())
-			.register()
+                        .withSubcommand(getQuestCommand())
+                        .withSubcommand(getHelpCommand())
+                        .withSubcommand(getReloadCommand())
+                        .withSubcommand(getNPCCommand())
+                        .withSubcommand(getSessionCommand())
+                        .register()
 	}
 
 	private fun listCommands(): String {
@@ -41,9 +43,10 @@ class StoryCommand(
 			<yellow>=========================</yellow>
 			<gold>/story</gold> help <gray><italic>- Show this help message</italic></gray>
 			<gold>/story</gold> reload <gray><italic>- Reload the plugin configuration</italic></gray>
-			<gold>/story</gold> location <gray><italic>- Manage locations</italic></gray>
-			<gold>/story</gold> npc <gray><italic>- Manage NPCs</italic></gray>
-			<gold>/conv</gold> list <gray><italic>- List all conversations and control panel</italic></gray>
+                        <gold>/story</gold> location <gray><italic>- Manage locations</italic></gray>
+                        <gold>/story</gold> npc <gray><italic>- Manage NPCs</italic></gray>
+                        <gold>/story</gold> session <gray><italic>- Track gameplay sessions</italic></gray>
+                        <gold>/conv</gold> list <gray><italic>- List all conversations and control panel</italic></gray>
 			""".trimIndent()
 	}
 
@@ -75,5 +78,7 @@ class StoryCommand(
 
 	private fun getQuestCommand(): CommandAPICommand = QuestCommand(plugin).getCommand()
 
-	private fun getNPCCommand(): CommandAPICommand = NPCCommand(plugin).getCommand()
+        private fun getNPCCommand(): CommandAPICommand = NPCCommand(plugin).getCommand()
+
+        private fun getSessionCommand(): CommandAPICommand = SessionCommand(plugin).getCommand()
 }

--- a/src/main/kotlin/com/canefe/story/command/story/session/SessionCommand.kt
+++ b/src/main/kotlin/com/canefe/story/command/story/session/SessionCommand.kt
@@ -1,0 +1,61 @@
+package com.canefe.story.command.story.session
+
+import com.canefe.story.Story
+import com.canefe.story.command.base.BaseCommand
+import com.canefe.story.util.Msg.sendSuccess
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.GreedyStringArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.jorel.commandapi.executors.CommandExecutor
+
+class SessionCommand(private val plugin: Story) : BaseCommand {
+    private val utils = SessionCommandUtils()
+
+    override fun register() {
+        CommandAPICommand("session")
+            .withPermission("story.session")
+            .withSubcommand(getStartCommand())
+            .withSubcommand(getAddCommand())
+            .withSubcommand(getFeedCommand())
+            .withSubcommand(getEndCommand())
+            .register()
+    }
+
+    private fun getStartCommand(): CommandAPICommand =
+        CommandAPICommand("start")
+            .executes(CommandExecutor { sender, _ ->
+                utils.sessionManager.startSession()
+                sender.sendSuccess("Session started.")
+            })
+
+    private fun getEndCommand(): CommandAPICommand =
+        CommandAPICommand("end")
+            .executes(CommandExecutor { sender, _ ->
+                utils.sessionManager.endSession()
+                sender.sendSuccess("Session ended.")
+            })
+
+    private fun getAddCommand(): CommandAPICommand =
+        CommandAPICommand("add")
+            .withArguments(
+                StringArgument("player")
+                    .replaceSuggestions(ArgumentSuggestions.strings { _ ->
+                        plugin.server.onlinePlayers.map { it.name }.toTypedArray()
+                    })
+            )
+            .executes(CommandExecutor { sender, args ->
+                val name = args.get("player") as String
+                utils.sessionManager.addPlayer(name)
+                sender.sendSuccess("Added $name to session.")
+            })
+
+    private fun getFeedCommand(): CommandAPICommand =
+        CommandAPICommand("feed")
+            .withArguments(GreedyStringArgument("text"))
+            .executes(CommandExecutor { sender, args ->
+                val text = args.get("text") as String
+                utils.sessionManager.feed(text)
+                sender.sendSuccess("Noted: $text")
+            })
+}

--- a/src/main/kotlin/com/canefe/story/command/story/session/SessionCommandUtils.kt
+++ b/src/main/kotlin/com/canefe/story/command/story/session/SessionCommandUtils.kt
@@ -1,0 +1,11 @@
+package com.canefe.story.command.story.session
+
+import com.canefe.story.Story
+import com.canefe.story.session.SessionManager
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+class SessionCommandUtils {
+    val story: Story = Story.instance
+    val mm: MiniMessage = story.miniMessage
+    val sessionManager: SessionManager = story.sessionManager
+}

--- a/src/main/kotlin/com/canefe/story/session/Session.kt
+++ b/src/main/kotlin/com/canefe/story/session/Session.kt
@@ -1,0 +1,12 @@
+package com.canefe.story.session
+
+/**
+ * Data class representing a gameplay session.
+ */
+data class Session(
+    val startTime: Long,
+    val players: MutableSet<String> = mutableSetOf(),
+    val history: MutableList<String> = mutableListOf(),
+) {
+    var endTime: Long? = null
+}

--- a/src/main/kotlin/com/canefe/story/session/SessionManager.kt
+++ b/src/main/kotlin/com/canefe/story/session/SessionManager.kt
@@ -1,0 +1,68 @@
+package com.canefe.story.session
+
+import com.canefe.story.Story
+import org.bukkit.configuration.file.YamlConfiguration
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Manager to track gameplay sessions and persist them to YAML files.
+ */
+class SessionManager private constructor(private val plugin: Story) {
+    private val sessionFolder: File =
+        File(plugin.dataFolder, "sessions").apply { if (!exists()) mkdirs() }
+
+    private val current = AtomicReference<Session?>(null)
+
+    /** Start a new session if none is active. */
+    fun startSession() {
+        if (current.get() != null) return
+        val session = Session(plugin.timeService.getCurrentGameTime())
+        current.set(session)
+    }
+
+    /** Add a player name to the active session. */
+    fun addPlayer(name: String) {
+        current.get()?.players?.add(name)
+    }
+
+    /** Append arbitrary text to the session history. */
+    fun feed(text: String) {
+        current.get()?.history?.add(text)
+    }
+
+    /** End the active session and persist it to disk. */
+    fun endSession() {
+        val session = current.getAndSet(null) ?: return
+        session.endTime = plugin.timeService.getCurrentGameTime()
+        saveSession(session)
+    }
+
+    private fun saveSession(session: Session) {
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MM-dd-yyyy_HH-mm-ss"))
+        val file = File(sessionFolder, "session-$timestamp.yml")
+        val config = YamlConfiguration()
+        config.set("startTime", session.startTime)
+        session.endTime?.let { config.set("endTime", it) }
+        config.set("players", session.players.toList())
+        config.set("history", session.history)
+        config.save(file)
+    }
+
+    /** Persist and clear the current session. */
+    fun shutdown() {
+        current.getAndSet(null)?.let { session ->
+            session.endTime = plugin.timeService.getCurrentGameTime()
+            saveSession(session)
+        }
+    }
+
+    companion object {
+        private var instance: SessionManager? = null
+        @JvmStatic
+        fun getInstance(plugin: Story): SessionManager =
+            instance ?: synchronized(this) { instance ?: SessionManager(plugin).also { instance = it } }
+    }
+}


### PR DESCRIPTION
## Summary
- track gameplay sessions in YAML files
- add `/story session` command for starting, feeding and ending sessions
- initialise new `SessionManager` in the plugin

## Testing
- `./gradlew test -i` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68407dea70d0832789add11cb08487a5